### PR TITLE
feat: scaffold clubcraft saas platform

### DIFF
--- a/clubcraft-saas/.github/workflows/ci.yml
+++ b/clubcraft-saas/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - name: Install dependencies
+        run: pnpm install
+      - name: Lint
+        run: pnpm lint
+      - name: Test
+        run: pnpm test
+      - name: Build frontend
+        run: pnpm --filter frontend build
+      - name: Build backend
+        run: pnpm --filter backend build
+
+  terraform-plan:
+    runs-on: ubuntu-latest
+    needs: build-test
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.6.6
+      - name: Terraform Init
+        working-directory: infra
+        run: terraform init
+      - name: Terraform Validate
+        working-directory: infra
+        run: terraform validate
+      - name: Terraform Plan
+        working-directory: infra
+        run: terraform plan -input=false

--- a/clubcraft-saas/.gitignore
+++ b/clubcraft-saas/.gitignore
@@ -1,0 +1,14 @@
+node_modules
+.pnpm-store
+.env
+.env.local
+.DS_Store
+.next
+out
+coverage
+pnpm-lock.yaml
+terraform.tfstate
+terraform.tfstate.backup
+.terraform/
+**/.turbo
+**/.DS_Store

--- a/clubcraft-saas/LICENSE
+++ b/clubcraft-saas/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 ClubCraft
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/clubcraft-saas/README.md
+++ b/clubcraft-saas/README.md
@@ -1,0 +1,66 @@
+# ClubCraft SaaS
+
+ClubCraft SaaS is a full-stack platform for managing private clubs, real estate investments, and proposal workflows. The project is organized as a pnpm workspace with a Next.js frontend, Fastify backend, infrastructure as code via Terraform, and SDKs for client integrations.
+
+## Project Structure
+
+```
+clubcraft-saas/
+├── backend/        # Fastify + TypeScript API server
+├── frontend/       # Next.js 14 + TailwindCSS app
+├── infra/          # Terraform for AWS (EKS, RDS, S3, CloudFront)
+├── docs/           # Markdown documentation (API, SDK, setup)
+├── sdk/            # Client SDKs (JavaScript, Python)
+├── docker-compose.yml # Local Postgres + Redis + Stripe CLI
+└── pnpm-workspace.yaml
+```
+
+## Getting Started
+
+1. Install dependencies (WSL-friendly):
+
+   ```bash
+   corepack enable
+   pnpm install
+   ```
+
+2. Copy environment variables:
+
+   ```bash
+   cp config/.env.example .env
+   ```
+
+3. Start local services:
+
+   ```bash
+   docker-compose up -d
+   ```
+
+4. Run the backend in development mode:
+
+   ```bash
+   pnpm --filter backend dev
+   ```
+
+5. Run the frontend:
+
+   ```bash
+   pnpm --filter frontend dev
+   ```
+
+## Testing
+
+Run unit and integration tests via pnpm:
+
+```bash
+pnpm test
+```
+
+## Deployment
+
+- CI/CD is defined in `.github/workflows/ci.yml` and executes linting, tests, and Terraform plan.
+- Infrastructure definitions are under `infra/`. Review Terraform variables before applying.
+
+## Licensing
+
+MIT License. See `LICENSE` file for details.

--- a/clubcraft-saas/backend/.eslintrc.cjs
+++ b/clubcraft-saas/backend/.eslintrc.cjs
@@ -1,0 +1,13 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint'],
+  extends: ['standard-with-typescript'],
+  parserOptions: {
+    project: ['./tsconfig.json']
+  },
+  env: {
+    node: true,
+    jest: true
+  }
+};

--- a/clubcraft-saas/backend/Dockerfile
+++ b/clubcraft-saas/backend/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:20-alpine AS base
+WORKDIR /app
+COPY package.json pnpm-lock.yaml* tsconfig.json tsup.config.ts jest.config.ts ./
+COPY prisma ./prisma
+RUN corepack enable && pnpm install --prod=false
+COPY src ./src
+RUN pnpm build
+
+FROM node:20-alpine
+WORKDIR /app
+COPY --from=base /app/dist ./dist
+COPY --from=base /app/node_modules ./node_modules
+COPY package.json ./package.json
+CMD ["node", "dist/index.js"]

--- a/clubcraft-saas/backend/__tests__/clubs.test.ts
+++ b/clubcraft-saas/backend/__tests__/clubs.test.ts
@@ -1,0 +1,72 @@
+import { createApp } from '../src/server';
+import type { FastifyInstance } from 'fastify';
+
+describe('Clubs routes', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = 'test';
+    process.env.DATABASE_URL = process.env.DATABASE_URL ?? 'postgresql://test:test@localhost:5432/test';
+    process.env.REDIS_URL = process.env.REDIS_URL ?? 'redis://localhost:6379';
+    process.env.JWT_SECRET = process.env.JWT_SECRET ?? 'test-secret-123456789';
+    process.env.STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY ?? 'sk_test_123';
+
+    app = await createApp();
+
+    app.prisma.club.findMany = jest.fn().mockResolvedValue([
+      { id: '1', name: 'Alpha', description: null, createdAt: new Date(), updatedAt: new Date() }
+    ]) as any;
+    app.prisma.club.count = jest.fn().mockResolvedValue(1) as any;
+    app.prisma.club.create = jest.fn().mockImplementation(async ({ data }) => ({
+      id: 'new-club',
+      name: data.name,
+      description: data.description ?? null,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    })) as any;
+    app.prisma.club.findUnique = jest.fn().mockResolvedValue({
+      id: '1',
+      name: 'Alpha',
+      description: null,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    }) as any;
+    app.prisma.club.update = jest.fn().mockResolvedValue({
+      id: '1',
+      name: 'Alpha Updated',
+      description: 'Updated',
+      createdAt: new Date(),
+      updatedAt: new Date()
+    }) as any;
+    app.prisma.club.delete = jest.fn().mockResolvedValue({ id: '1' }) as any;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('lists clubs', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/clubs',
+      headers: { authorization: `Bearer ${app.jwt.sign({ userId: '1', role: 'Viewer' })}` }
+    });
+
+    expect(response.statusCode).toBe(200);
+    const payload = response.json();
+    expect(payload.data).toHaveLength(1);
+    expect(payload.meta.total).toBe(1);
+  });
+
+  it('creates club', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/clubs',
+      payload: { name: 'Beta Club' },
+      headers: { authorization: `Bearer ${app.jwt.sign({ userId: '1', role: 'Owner' })}` }
+    });
+
+    expect(response.statusCode).toBe(201);
+    expect(response.json().name).toBe('Beta Club');
+  });
+});

--- a/clubcraft-saas/backend/jest.config.ts
+++ b/clubcraft-saas/backend/jest.config.ts
@@ -1,0 +1,18 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/__tests__'],
+  moduleFileExtensions: ['ts', 'js'],
+  coverageDirectory: 'coverage',
+  extensionsToTreatAsEsm: ['.ts'],
+  globals: {
+    'ts-jest': {
+      useESM: true,
+      tsconfig: './tsconfig.json'
+    }
+  }
+};
+
+export default config;

--- a/clubcraft-saas/backend/package.json
+++ b/clubcraft-saas/backend/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "backend",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsup src/index.ts --format esm --dts --out-dir dist",
+    "start": "node dist/index.js",
+    "lint": "eslint 'src/**/*.{ts,tsx}'",
+    "test": "jest",
+    "db:generate": "prisma generate",
+    "db:migrate": "prisma migrate deploy"
+  },
+  "dependencies": {
+    "@fastify/cors": "^9.0.1",
+    "@fastify/helmet": "^12.1.1",
+    "@fastify/jwt": "^9.2.0",
+    "@fastify/sensible": "^5.5.0",
+    "@fastify/webhook": "^3.0.0",
+    "@prisma/client": "^5.9.1",
+    "dotenv": "^16.3.1",
+    "fastify": "^4.26.2",
+    "fastify-plugin": "^4.5.1",
+    "fastify-swagger": "^8.11.0",
+    "ioredis": "^5.3.2",
+    "jsonwebtoken": "^9.0.2",
+    "p-retry": "^6.0.1",
+    "stripe": "^14.22.0",
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.12",
+    "@types/jsonwebtoken": "^9.0.5",
+    "@types/node": "^20.11.25",
+    "@types/supertest": "^2.0.16",
+    "eslint": "^8.56.0",
+    "eslint-config-standard-with-typescript": "^39.1.1",
+    "eslint-plugin-import": "^2.29.1",
+    "eslint-plugin-n": "^16.6.2",
+    "eslint-plugin-promise": "^6.1.1",
+    "jest": "^29.7.0",
+    "prisma": "^5.9.1",
+    "supertest": "^6.3.3",
+    "ts-jest": "^29.1.1",
+    "tsup": "^8.0.1",
+    "tsx": "^4.7.0",
+    "typescript": "^5.3.3"
+  }
+}

--- a/clubcraft-saas/backend/prisma/migrations/000_init/migration.sql
+++ b/clubcraft-saas/backend/prisma/migrations/000_init/migration.sql
@@ -1,0 +1,51 @@
+CREATE TYPE "Role" AS ENUM ('Owner', 'Admin', 'Treasurer', 'Member', 'Viewer');
+
+CREATE TABLE "Club" (
+  "id" TEXT PRIMARY KEY,
+  "name" TEXT NOT NULL,
+  "description" TEXT,
+  "createdAt" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE "Member" (
+  "id" TEXT PRIMARY KEY,
+  "email" TEXT NOT NULL UNIQUE,
+  "fullName" TEXT NOT NULL,
+  "role" "Role" DEFAULT 'Viewer',
+  "clubId" TEXT NOT NULL,
+  "createdAt" TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT fk_member_club FOREIGN KEY("clubId") REFERENCES "Club"("id") ON DELETE CASCADE
+);
+
+CREATE TABLE "Transaction" (
+  "id" TEXT PRIMARY KEY,
+  "clubId" TEXT NOT NULL,
+  "amount" DECIMAL(18,2) NOT NULL,
+  "type" TEXT NOT NULL,
+  "occurredAt" TIMESTAMP NOT NULL,
+  "metadata" JSONB,
+  CONSTRAINT fk_transaction_club FOREIGN KEY("clubId") REFERENCES "Club"("id") ON DELETE CASCADE
+);
+
+CREATE TABLE "Property" (
+  "id" TEXT PRIMARY KEY,
+  "clubId" TEXT NOT NULL,
+  "address" TEXT NOT NULL,
+  "status" TEXT NOT NULL,
+  "valuation" DECIMAL(18,2),
+  "acquiredAt" TIMESTAMP,
+  CONSTRAINT fk_property_club FOREIGN KEY("clubId") REFERENCES "Club"("id") ON DELETE CASCADE
+);
+
+CREATE OR REPLACE FUNCTION trigger_set_timestamp()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW."updatedAt" = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER update_club_timestamp
+BEFORE UPDATE ON "Club"
+FOR EACH ROW EXECUTE FUNCTION trigger_set_timestamp();

--- a/clubcraft-saas/backend/prisma/schema.prisma
+++ b/clubcraft-saas/backend/prisma/schema.prisma
@@ -1,0 +1,57 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum Role {
+  Owner
+  Admin
+  Treasurer
+  Member
+  Viewer
+}
+
+model Club {
+  id          String        @id @default(cuid())
+  name        String
+  description String?
+  createdAt   DateTime      @default(now())
+  updatedAt   DateTime      @updatedAt
+  members     Member[]
+  transactions Transaction[]
+  properties  Property[]
+}
+
+model Member {
+  id        String   @id @default(cuid())
+  email     String   @unique
+  fullName  String
+  role      Role     @default(Viewer)
+  clubId    String
+  club      Club     @relation(fields: [clubId], references: [id], onDelete: Cascade)
+  createdAt DateTime @default(now())
+}
+
+model Transaction {
+  id        String   @id @default(cuid())
+  clubId    String
+  club      Club     @relation(fields: [clubId], references: [id], onDelete: Cascade)
+  amount    Decimal  @db.Decimal(18, 2)
+  type      String
+  occurredAt DateTime
+  metadata  Json?
+}
+
+model Property {
+  id          String   @id @default(cuid())
+  clubId      String
+  club        Club     @relation(fields: [clubId], references: [id], onDelete: Cascade)
+  address     String
+  status      String
+  valuation   Decimal? @db.Decimal(18, 2)
+  acquiredAt  DateTime?
+}

--- a/clubcraft-saas/backend/src/domain/rbac.ts
+++ b/clubcraft-saas/backend/src/domain/rbac.ts
@@ -1,0 +1,14 @@
+export type Role = 'Owner' | 'Admin' | 'Treasurer' | 'Member' | 'Viewer';
+
+export const roleHierarchy: Record<Role, number> = {
+  Owner: 5,
+  Admin: 4,
+  Treasurer: 3,
+  Member: 2,
+  Viewer: 1
+};
+
+export function canAccess(userRole: Role, allowed: Role[]) {
+  if (allowed.length === 0) return true;
+  return allowed.some((role) => roleHierarchy[userRole] >= roleHierarchy[role]);
+}

--- a/clubcraft-saas/backend/src/env.ts
+++ b/clubcraft-saas/backend/src/env.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const envSchema = z.object({
+  NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
+  PORT: z.coerce.number().default(4000),
+  DATABASE_URL: z.string().url(),
+  REDIS_URL: z.string().url(),
+  JWT_SECRET: z.string().min(16),
+  JWT_EXPIRES_IN: z.string().default('1d'),
+  STRIPE_SECRET_KEY: z.string(),
+  STRIPE_WEBHOOK_SECRET: z.string().optional(),
+  POLYGON_API_KEY: z.string().optional(),
+  CRUNCHBASE_API_KEY: z.string().optional(),
+  GOOGLE_ADS_CLIENT_ID: z.string().optional(),
+  GOOGLE_ADS_CLIENT_SECRET: z.string().optional(),
+  GOOGLE_ADS_REFRESH_TOKEN: z.string().optional(),
+  META_ADS_ACCESS_TOKEN: z.string().optional()
+});
+
+export const env = envSchema.parse(process.env);

--- a/clubcraft-saas/backend/src/index.ts
+++ b/clubcraft-saas/backend/src/index.ts
@@ -1,0 +1,15 @@
+import { createApp } from './server';
+import { env } from './env';
+
+async function bootstrap() {
+  const app = await createApp();
+  try {
+    await app.listen({ port: env.PORT, host: '0.0.0.0' });
+    app.log.info(`🚀 Server ready on port ${env.PORT}`);
+  } catch (error) {
+    app.log.error(error);
+    process.exit(1);
+  }
+}
+
+void bootstrap();

--- a/clubcraft-saas/backend/src/plugins/auth.ts
+++ b/clubcraft-saas/backend/src/plugins/auth.ts
@@ -1,0 +1,40 @@
+import fp from 'fastify-plugin';
+import { FastifyReply, FastifyRequest } from 'fastify';
+import { canAccess, Role } from '../domain/rbac';
+
+declare module '@fastify/jwt' {
+  interface FastifyJWT {
+    payload: { userId: string; role: Role };
+    user: { userId: string; role: Role };
+  }
+}
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    authenticate: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
+    authorize: (roles?: Role[]) => (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
+  }
+}
+
+export const authPlugin = fp(async (app) => {
+  app.decorate('authenticate', async (request: FastifyRequest, reply: FastifyReply) => {
+    try {
+      await request.jwtVerify();
+    } catch (err) {
+      return reply.unauthorized();
+    }
+  });
+
+  app.decorate('authorize', (roles: Role[] = []) => {
+    return async (request: FastifyRequest, reply: FastifyReply) => {
+      const authResult = await app.authenticate(request, reply);
+      if (authResult) {
+        return authResult;
+      }
+      const userRole = request.user?.role ?? 'Viewer';
+      if (!canAccess(userRole, roles)) {
+        return reply.forbidden();
+      }
+    };
+  });
+});

--- a/clubcraft-saas/backend/src/plugins/prisma.ts
+++ b/clubcraft-saas/backend/src/plugins/prisma.ts
@@ -1,0 +1,24 @@
+import fp from 'fastify-plugin';
+import { PrismaClient } from '@prisma/client';
+import { env } from '../env';
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    prisma: PrismaClient;
+  }
+}
+
+const prisma = new PrismaClient();
+
+export const prismaPlugin = fp(async (app) => {
+  if (env.NODE_ENV !== 'test') {
+    await prisma.$connect();
+  }
+  app.decorate('prisma', prisma);
+
+  app.addHook('onClose', async () => {
+    if (env.NODE_ENV !== 'test') {
+      await prisma.$disconnect();
+    }
+  });
+});

--- a/clubcraft-saas/backend/src/plugins/redis.ts
+++ b/clubcraft-saas/backend/src/plugins/redis.ts
@@ -1,0 +1,45 @@
+import fp from 'fastify-plugin';
+import Redis from 'ioredis';
+import { env } from '../env';
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    redis: Pick<Redis, 'get' | 'set' | 'del' | 'quit'>;
+  }
+}
+
+class MemoryRedis {
+  private store = new Map<string, string>();
+
+  async get(key: string) {
+    return this.store.get(key) ?? null;
+  }
+
+  async set(key: string, value: string, mode?: string, duration?: number) {
+    this.store.set(key, value);
+    if (mode === 'EX' && duration) {
+      setTimeout(() => this.store.delete(key), duration * 1000).unref?.();
+    }
+    return 'OK';
+  }
+
+  async del(key: string) {
+    this.store.delete(key);
+    return 1;
+  }
+
+  async quit() {
+    this.store.clear();
+  }
+}
+
+type RedisLike = Pick<Redis, 'get' | 'set' | 'del' | 'quit'> | MemoryRedis;
+
+export const redisPlugin = fp(async (app) => {
+  const client: RedisLike = env.NODE_ENV === 'test' ? new MemoryRedis() : new Redis(env.REDIS_URL);
+  app.decorate('redis', client);
+
+  app.addHook('onClose', async () => {
+    await client.quit();
+  });
+});

--- a/clubcraft-saas/backend/src/routes/auth.ts
+++ b/clubcraft-saas/backend/src/routes/auth.ts
@@ -1,0 +1,26 @@
+import { FastifyPluginAsync } from 'fastify';
+import { z } from 'zod';
+
+const authRoutes: FastifyPluginAsync = async (app) => {
+  app.post('/login', async (request, reply) => {
+    const bodySchema = z.object({
+      email: z.string().email(),
+      password: z.string().min(6)
+    });
+
+    const body = bodySchema.parse(request.body);
+
+    // TODO: Replace with real password verification
+    const user = {
+      id: 'user-1',
+      email: body.email,
+      role: 'Owner' as const
+    };
+
+    const token = app.jwt.sign({ userId: user.id, role: user.role });
+
+    return reply.send({ token, user });
+  });
+};
+
+export default authRoutes;

--- a/clubcraft-saas/backend/src/routes/billing.ts
+++ b/clubcraft-saas/backend/src/routes/billing.ts
@@ -1,0 +1,19 @@
+import { FastifyPluginAsync } from 'fastify';
+import { z } from 'zod';
+import { stripeService } from '../services/stripeService';
+
+const subscribeSchema = z.object({
+  customerId: z.string(),
+  priceId: z.string(),
+  paymentMethodId: z.string()
+});
+
+const billingRoutes: FastifyPluginAsync = async (app) => {
+  app.post('/subscribe', { preHandler: app.authorize(['Admin', 'Owner']) }, async (request, reply) => {
+    const body = subscribeSchema.parse(request.body);
+    const subscription = await stripeService.createSubscription(body);
+    return reply.send(subscription);
+  });
+};
+
+export default billingRoutes;

--- a/clubcraft-saas/backend/src/routes/clubs.ts
+++ b/clubcraft-saas/backend/src/routes/clubs.ts
@@ -1,0 +1,65 @@
+import { FastifyPluginAsync } from 'fastify';
+import { createClubSchema, updateClubSchema, paginationSchema } from '../schemas/club';
+
+const clubsRoutes: FastifyPluginAsync = async (app) => {
+  app.get('/', { preHandler: app.authorize(['Viewer']) }, async (request) => {
+    const query = paginationSchema.parse(request.query);
+    const [data, total] = await Promise.all([
+      app.prisma.club.findMany({
+        skip: (query.page - 1) * query.pageSize,
+        take: query.pageSize,
+        orderBy: { createdAt: 'desc' }
+      }),
+      app.prisma.club.count()
+    ]);
+
+    return {
+      data,
+      meta: {
+        page: query.page,
+        pageSize: query.pageSize,
+        total
+      }
+    };
+  });
+
+  app.post('/', { preHandler: app.authorize(['Treasurer', 'Admin', 'Owner']) }, async (request, reply) => {
+    const body = createClubSchema.parse(request.body);
+    const club = await app.prisma.club.create({ data: body });
+    await app.redis.del('clubs:list');
+    return reply.code(201).send(club);
+  });
+
+  app.get('/:id', { preHandler: app.authorize(['Viewer']) }, async (request, reply) => {
+    const { id } = request.params as { id: string };
+    const cacheKey = `club:${id}`;
+    const cached = await app.redis.get(cacheKey);
+    if (cached) {
+      return JSON.parse(cached);
+    }
+
+    const club = await app.prisma.club.findUnique({ where: { id } });
+    if (!club) {
+      return reply.notFound('Club not found');
+    }
+    await app.redis.set(cacheKey, JSON.stringify(club), 'EX', 60);
+    return club;
+  });
+
+  app.put('/:id', { preHandler: app.authorize(['Admin', 'Owner']) }, async (request, reply) => {
+    const { id } = request.params as { id: string };
+    const body = updateClubSchema.parse(request.body);
+    const club = await app.prisma.club.update({ where: { id }, data: body });
+    await app.redis.del(`club:${id}`);
+    return reply.send(club);
+  });
+
+  app.delete('/:id', { preHandler: app.authorize(['Owner']) }, async (request, reply) => {
+    const { id } = request.params as { id: string };
+    await app.prisma.club.delete({ where: { id } });
+    await app.redis.del(`club:${id}`);
+    return reply.code(204).send();
+  });
+};
+
+export default clubsRoutes;

--- a/clubcraft-saas/backend/src/routes/webhooks.ts
+++ b/clubcraft-saas/backend/src/routes/webhooks.ts
@@ -1,0 +1,31 @@
+import { FastifyPluginAsync } from 'fastify';
+import Stripe from 'stripe';
+import { env } from '../env';
+import { stripeService } from '../services/stripeService';
+
+const webhookSecret = env.STRIPE_WEBHOOK_SECRET;
+
+const webhookRoutes: FastifyPluginAsync = async (app) => {
+  app.post('/stripe', async (request, reply) => {
+    const signature = request.headers['stripe-signature'];
+    const payload = typeof request.body === 'string' ? request.body : JSON.stringify(request.body ?? {});
+
+    if (!signature || !webhookSecret) {
+      request.log.warn('Missing Stripe signature or webhook secret.');
+      return reply.code(400).send({ error: 'Invalid webhook configuration' });
+    }
+
+    let event: Stripe.Event;
+    try {
+      event = stripeService.constructWebhookEvent(payload, signature, webhookSecret);
+    } catch (error) {
+      request.log.error(error);
+      return reply.code(400).send({ error: 'Webhook signature verification failed' });
+    }
+
+    request.log.info({ type: event.type }, 'Received Stripe event');
+    return reply.code(200).send({ received: true });
+  });
+};
+
+export default webhookRoutes;

--- a/clubcraft-saas/backend/src/schemas/club.ts
+++ b/clubcraft-saas/backend/src/schemas/club.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+export const createClubSchema = z.object({
+  name: z.string().min(2),
+  description: z.string().optional()
+});
+
+export const updateClubSchema = createClubSchema.partial();
+
+export const paginationSchema = z.object({
+  page: z.coerce.number().min(1).default(1),
+  pageSize: z.coerce.number().min(1).max(100).default(10)
+});

--- a/clubcraft-saas/backend/src/server.ts
+++ b/clubcraft-saas/backend/src/server.ts
@@ -1,0 +1,39 @@
+import Fastify from 'fastify';
+import fastifyCors from '@fastify/cors';
+import fastifyHelmet from '@fastify/helmet';
+import fastifySensible from '@fastify/sensible';
+import fastifyJwt from '@fastify/jwt';
+import { env } from './env';
+import { prismaPlugin } from './plugins/prisma';
+import { redisPlugin } from './plugins/redis';
+import { authPlugin } from './plugins/auth';
+import clubsRoutes from './routes/clubs';
+import authRoutes from './routes/auth';
+import billingRoutes from './routes/billing';
+import webhookRoutes from './routes/webhooks';
+
+export async function createApp() {
+  const app = Fastify({
+    logger: true
+  });
+
+  await app.register(fastifyHelmet, { contentSecurityPolicy: false });
+  await app.register(fastifyCors, { origin: true, credentials: true });
+  await app.register(fastifySensible);
+  await app.register(prismaPlugin);
+  await app.register(redisPlugin);
+  await app.register(fastifyJwt, {
+    secret: env.JWT_SECRET,
+    sign: { expiresIn: env.JWT_EXPIRES_IN }
+  });
+  await app.register(authPlugin);
+
+  await app.register(authRoutes, { prefix: '/auth' });
+  await app.register(clubsRoutes, { prefix: '/clubs' });
+  await app.register(billingRoutes, { prefix: '/billing' });
+  await app.register(webhookRoutes, { prefix: '/webhooks' });
+
+  app.get('/health', async () => ({ status: 'ok' }));
+
+  return app;
+}

--- a/clubcraft-saas/backend/src/services/crunchbaseService.ts
+++ b/clubcraft-saas/backend/src/services/crunchbaseService.ts
@@ -1,0 +1,33 @@
+import { env } from '../env';
+import { withRetry } from './retry';
+
+export interface CrunchbaseOrganization {
+  name: string;
+  permalink: string;
+  primaryRole: string;
+}
+
+export const crunchbaseService = {
+  async searchOrganizations(query: string): Promise<CrunchbaseOrganization[]> {
+    return withRetry(async () => {
+      const response = await fetch('https://api.crunchbase.com/api/v4/searches/organizations', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Cb-User-Key': env.CRUNCHBASE_API_KEY ?? ''
+        },
+        body: JSON.stringify({ query: [{ field_id: 'organization_name', operator_id: 'contains', values: [query] }] })
+      });
+
+      if (!response.ok) {
+        throw new Error(`Crunchbase API error: ${response.statusText}`);
+      }
+      const data = await response.json();
+      return data.entities?.map((entity: any) => ({
+        name: entity.properties?.name ?? 'Unknown',
+        permalink: entity.properties?.permalink,
+        primaryRole: entity.properties?.primary_role ?? 'unknown'
+      })) ?? [];
+    });
+  }
+};

--- a/clubcraft-saas/backend/src/services/googleAdsService.ts
+++ b/clubcraft-saas/backend/src/services/googleAdsService.ts
@@ -1,0 +1,26 @@
+import { withRetry } from './retry';
+
+export interface CampaignInsight {
+  id: string;
+  name: string;
+  impressions: number;
+  clicks: number;
+  spend: number;
+}
+
+export const googleAdsService = {
+  async listCampaignInsights(customerId: string): Promise<CampaignInsight[]> {
+    return withRetry(async () => {
+      // Placeholder for Google Ads API client
+      return [
+        {
+          id: 'cmp-1',
+          name: `Sample Campaign for ${customerId}`,
+          impressions: 12000,
+          clicks: 420,
+          spend: 860.5
+        }
+      ];
+    });
+  }
+};

--- a/clubcraft-saas/backend/src/services/metaAdsService.ts
+++ b/clubcraft-saas/backend/src/services/metaAdsService.ts
@@ -1,0 +1,22 @@
+import { withRetry } from './retry';
+
+export interface MetaAdSummary {
+  campaignName: string;
+  reach: number;
+  ctr: number;
+}
+
+export const metaAdsService = {
+  async summarizeAccount(accountId: string): Promise<MetaAdSummary[]> {
+    return withRetry(async () => {
+      // Placeholder for Meta Ads Graph API integration
+      return [
+        {
+          campaignName: `Awareness - ${accountId}`,
+          reach: 54000,
+          ctr: 3.4
+        }
+      ];
+    });
+  }
+};

--- a/clubcraft-saas/backend/src/services/polygonService.ts
+++ b/clubcraft-saas/backend/src/services/polygonService.ts
@@ -1,0 +1,25 @@
+import { env } from '../env';
+import { withRetry } from './retry';
+
+export interface MarketQuote {
+  symbol: string;
+  price: number;
+  updatedAt: string;
+}
+
+export const polygonService = {
+  async getLatestQuote(symbol: string): Promise<MarketQuote> {
+    return withRetry(async () => {
+      const response = await fetch(`https://api.polygon.io/v2/last/trade/${symbol}?apiKey=${env.POLYGON_API_KEY}`);
+      if (!response.ok) {
+        throw new Error(`Polygon API error: ${response.statusText}`);
+      }
+      const data = await response.json();
+      return {
+        symbol,
+        price: data.last?.price ?? 0,
+        updatedAt: data.last?.timestamp ?? new Date().toISOString()
+      };
+    });
+  }
+};

--- a/clubcraft-saas/backend/src/services/retry.ts
+++ b/clubcraft-saas/backend/src/services/retry.ts
@@ -1,0 +1,10 @@
+import pRetry, { Options } from 'p-retry';
+
+export async function withRetry<T>(fn: () => Promise<T>, options: Options = {}) {
+  return await pRetry(fn, {
+    retries: 3,
+    factor: 2,
+    minTimeout: 500,
+    ...options
+  });
+}

--- a/clubcraft-saas/backend/src/services/stripeService.ts
+++ b/clubcraft-saas/backend/src/services/stripeService.ts
@@ -1,0 +1,31 @@
+import Stripe from 'stripe';
+import { env } from '../env';
+
+const stripe = new Stripe(env.STRIPE_SECRET_KEY, { apiVersion: '2023-10-16' });
+
+export const STRIPE_PRICING = {
+  Starter: 'price_starter',
+  Growth: 'price_growth',
+  Pro: 'price_pro'
+} as const;
+
+export const stripeService = {
+  async createSubscription({ customerId, priceId, paymentMethodId }: { customerId: string; priceId: string; paymentMethodId: string }) {
+    await stripe.paymentMethods.attach(paymentMethodId, { customer: customerId });
+    await stripe.customers.update(customerId, { invoice_settings: { default_payment_method: paymentMethodId } });
+
+    const subscription = await stripe.subscriptions.create({
+      customer: customerId,
+      items: [{ price: priceId }],
+      expand: ['latest_invoice.payment_intent']
+    });
+
+    return {
+      subscriptionId: subscription.id,
+      status: subscription.status
+    };
+  },
+  constructWebhookEvent(payload: string | Buffer, signature: string | string[], secret: string) {
+    return stripe.webhooks.constructEvent(payload, signature, secret);
+  }
+};

--- a/clubcraft-saas/backend/tsconfig.json
+++ b/clubcraft-saas/backend/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "lib": ["ES2020", "DOM"],
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "outDir": "dist",
+    "types": ["node", "jest"]
+  },
+  "include": ["src/**/*.ts", "__tests__/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/clubcraft-saas/backend/tsup.config.ts
+++ b/clubcraft-saas/backend/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  dts: true,
+  target: 'es2020'
+});

--- a/clubcraft-saas/config/.env.example
+++ b/clubcraft-saas/config/.env.example
@@ -1,0 +1,23 @@
+# Core
+NODE_ENV=development
+PORT=4000
+
+# Database
+DATABASE_URL=postgresql://clubcraft:clubcraft@localhost:5432/clubcraft
+REDIS_URL=redis://localhost:6379
+
+# Auth
+JWT_SECRET=super-secret
+JWT_EXPIRES_IN=1d
+
+# Stripe
+STRIPE_SECRET_KEY=sk_test_123
+STRIPE_WEBHOOK_SECRET=whsec_123
+
+# Third-party APIs
+POLYGON_API_KEY=your_polygon_api_key
+CRUNCHBASE_API_KEY=your_crunchbase_api_key
+GOOGLE_ADS_CLIENT_ID=client_id
+GOOGLE_ADS_CLIENT_SECRET=client_secret
+GOOGLE_ADS_REFRESH_TOKEN=refresh_token
+META_ADS_ACCESS_TOKEN=access_token

--- a/clubcraft-saas/docker-compose.yml
+++ b/clubcraft-saas/docker-compose.yml
@@ -1,0 +1,50 @@
+version: '3.9'
+services:
+  postgres:
+    image: postgres:15
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: clubcraft
+      POSTGRES_PASSWORD: clubcraft
+      POSTGRES_DB: clubcraft
+    ports:
+      - '5432:5432'
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  redis:
+    image: redis:7
+    command: redis-server --save 20 1 --loglevel warning
+    ports:
+      - '6379:6379'
+    volumes:
+      - redisdata:/data
+
+  stripe:
+    image: stripe/stripe-cli:latest
+    entrypoint: ['stripe', 'listen', '--forward-to', 'http://host.docker.internal:4000/webhooks/stripe']
+    environment:
+      STRIPE_API_KEY: ${STRIPE_API_KEY:-sk_test_123}
+    depends_on:
+      - backend
+
+  backend:
+    build:
+      context: ./backend
+    command: pnpm dev
+    environment:
+      DATABASE_URL: postgresql://clubcraft:clubcraft@postgres:5432/clubcraft
+      REDIS_URL: redis://redis:6379
+      STRIPE_SECRET_KEY: ${STRIPE_SECRET_KEY:-sk_test_123}
+      JWT_SECRET: changeme
+    ports:
+      - '4000:4000'
+    volumes:
+      - ./backend:/app
+    depends_on:
+      - postgres
+      - redis
+
+volumes:
+  pgdata:
+  redisdata:

--- a/clubcraft-saas/docs/api.md
+++ b/clubcraft-saas/docs/api.md
@@ -1,0 +1,42 @@
+# API Documentation
+
+## Authentication
+All API requests require a JWT Bearer token. Obtain a token via the `/auth/login` endpoint.
+
+### Login
+- **POST** `/auth/login`
+- **Body:** `{ "email": string, "password": string }`
+- **Response:** `{ "token": string, "user": User }`
+
+## Clubs
+CRUD endpoints for managing clubs.
+
+### List Clubs
+- **GET** `/clubs`
+- **Query:** `page`, `pageSize`
+- **Response:** `{ "data": Club[], "meta": { "page": number, "pageSize": number, "total": number } }`
+
+### Create Club
+- **POST** `/clubs`
+- **Body:** `{ "name": string, "description?": string }`
+- **Permissions:** Owner, Admin, Treasurer
+
+### Get Club
+- **GET** `/clubs/:id`
+
+### Update Club
+- **PUT** `/clubs/:id`
+- **Permissions:** Owner, Admin
+
+### Delete Club
+- **DELETE** `/clubs/:id`
+- **Permissions:** Owner
+
+## Stripe Billing
+- **POST** `/billing/subscribe`
+- **Body:** `{ "priceId": string, "paymentMethodId": string }`
+- **Response:** `{ "subscriptionId": string, "status": string }`
+
+## Webhooks
+- **POST** `/webhooks/stripe`
+- Handles subscription lifecycle events. Verify signatures using `STRIPE_WEBHOOK_SECRET`.

--- a/clubcraft-saas/docs/sdk.md
+++ b/clubcraft-saas/docs/sdk.md
@@ -1,0 +1,39 @@
+# SDK Usage
+
+## JavaScript SDK
+Install via pnpm:
+
+```bash
+pnpm add @clubcraft/sdk
+```
+
+Usage:
+
+```ts
+import { ClubcraftClient } from '@clubcraft/sdk';
+
+const client = new ClubcraftClient({
+  baseUrl: 'http://localhost:4000',
+  token: 'your-jwt-token'
+});
+
+const clubs = await client.clubs.list();
+```
+
+## Python SDK
+Install locally:
+
+```bash
+pip install -e sdk/python
+```
+
+Usage:
+
+```python
+from clubcraft import ClubcraftClient
+
+client = ClubcraftClient(base_url="http://localhost:4000", token="your-jwt-token")
+clubs = client.clubs.list()
+```
+
+Both SDKs share the same REST endpoints described in `docs/api.md`.

--- a/clubcraft-saas/docs/setup.md
+++ b/clubcraft-saas/docs/setup.md
@@ -1,0 +1,37 @@
+# Setup Guide
+
+## Prerequisites
+- Node.js 20+
+- pnpm 8+
+- Docker + Docker Compose
+- Terraform 1.6+
+
+## Local Development
+1. Copy environment variables:
+   ```bash
+   cp config/.env.example .env
+   ```
+2. Start dependencies:
+   ```bash
+   docker-compose up -d postgres redis
+   ```
+3. Run database migrations:
+   ```bash
+   pnpm --filter backend db:migrate
+   ```
+4. Launch the backend API:
+   ```bash
+   pnpm --filter backend dev
+   ```
+5. Launch the frontend application:
+   ```bash
+   pnpm --filter frontend dev
+   ```
+
+## Testing
+- `pnpm --filter backend test`
+- `pnpm --filter frontend lint`
+
+## Deployment Notes
+- Configure AWS credentials for Terraform before running `terraform apply`.
+- Stripe webhook secret must be provided in production environments.

--- a/clubcraft-saas/frontend/.eslintrc.json
+++ b/clubcraft-saas/frontend/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/clubcraft-saas/frontend/app/dashboard/page.tsx
+++ b/clubcraft-saas/frontend/app/dashboard/page.tsx
@@ -1,0 +1,62 @@
+import Link from 'next/link';
+import { GlassCard } from '../../components/GlassCard';
+
+const cards = [
+  {
+    title: 'Clubs Overview',
+    description: 'Track capital calls, votes, and compliance tasks across all clubs.',
+    link: '#',
+    stats: ['Active clubs: 5', 'Pending votes: 3', 'NAV change: +4.2%']
+  },
+  {
+    title: 'Real Estate Portfolio',
+    description: 'Monitor occupancy, rent rolls, and renovation progress in real time.',
+    link: '#',
+    stats: ['Assets: 12', 'Occupancy: 96%', 'Pipeline deals: 4']
+  },
+  {
+    title: 'Proposals & Campaigns',
+    description: 'Launch investor proposals with integrated Google & Meta Ads intelligence.',
+    link: '#',
+    stats: ['Live proposals: 2', 'CTR (Ads): 3.8%', 'Crunchbase matches: 18']
+  }
+];
+
+export default function DashboardPage() {
+  return (
+    <div className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-10 px-6 py-16">
+      <div className="flex flex-col justify-between gap-6 sm:flex-row sm:items-center">
+        <div>
+          <h1 className="text-4xl font-bold text-white">ClubCraft Control Center</h1>
+          <p className="mt-2 text-sm text-white/70">
+            A snapshot of your clubs, property portfolio, and acquisition funnels.
+          </p>
+        </div>
+        <Link
+          href="/"
+          className="inline-flex items-center rounded-full border border-white/30 bg-white/10 px-6 py-3 text-sm font-semibold text-white transition hover:bg-white/20"
+        >
+          Back to marketing site
+        </Link>
+      </div>
+
+      <div className="grid gap-8 md:grid-cols-3">
+        {cards.map((card) => (
+          <GlassCard key={card.title} title={card.title} description={card.description}>
+            <ul className="space-y-2 text-sm text-white/70">
+              {card.stats.map((stat) => (
+                <li key={stat} className="flex items-center gap-2">
+                  <span className="h-1.5 w-1.5 rounded-full bg-primary-500" />
+                  <span>{stat}</span>
+                </li>
+              ))}
+            </ul>
+            <Link href={card.link} className="mt-6 inline-flex text-sm text-white/80 hover:text-white">
+              View details →
+            </Link>
+          </GlassCard>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/clubcraft-saas/frontend/app/globals.css
+++ b/clubcraft-saas/frontend/app/globals.css
@@ -1,0 +1,31 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+  background: radial-gradient(circle at top, rgba(81, 107, 255, 0.25), transparent 50%),
+    radial-gradient(circle at bottom, rgba(59, 78, 209, 0.35), transparent 55%),
+    #0f172a;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+body {
+  min-height: 100vh;
+  background: transparent;
+  color: #f8fafc;
+}
+
+a {
+  @apply text-primary-100 hover:text-white transition-colors;
+}
+
+.glass-panel {
+  @apply bg-white/10 border border-white/20 backdrop-blur-md rounded-3xl shadow-glass;
+}
+
+.text-gradient {
+  background: linear-gradient(135deg, #ffffff, rgba(81, 107, 255, 0.75));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}

--- a/clubcraft-saas/frontend/app/layout.tsx
+++ b/clubcraft-saas/frontend/app/layout.tsx
@@ -1,0 +1,20 @@
+import './globals.css';
+import type { Metadata } from 'next';
+import { ReactNode } from 'react';
+
+export const metadata: Metadata = {
+  title: 'ClubCraft SaaS',
+  description: 'Operate modern investment clubs with a glassmorphic control center.'
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-slate-950 text-slate-100 antialiased">
+        <div className="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950">
+          {children}
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/clubcraft-saas/frontend/app/page.tsx
+++ b/clubcraft-saas/frontend/app/page.tsx
@@ -1,0 +1,144 @@
+import { Navbar } from '../components/Navbar';
+import { PricingCard } from '../components/PricingCard';
+import { TestimonialCard } from '../components/TestimonialCard';
+import Link from 'next/link';
+
+const features = [
+  {
+    title: 'Unified Club OS',
+    description: 'Consolidate member records, votes, and communications with enterprise-grade security.'
+  },
+  {
+    title: 'Real Estate Intelligence',
+    description: 'Overlay market feeds from Polygon.io with your proprietary underwriting templates.'
+  },
+  {
+    title: 'Automated Proposals',
+    description: 'Launch investor-ready proposals with integrated Crunchbase and Ads campaign insights.'
+  }
+];
+
+const pricing = [
+  {
+    name: 'Starter',
+    price: '$149',
+    description: 'Launch your first investment club with core workflows.',
+    features: ['Up to 2 clubs', 'Member CRM', 'Financial reporting dashboards', 'Email support']
+  },
+  {
+    name: 'Growth',
+    price: '$349',
+    description: 'Scale deal flow with automation and insights.',
+    features: ['Unlimited clubs', 'Deal pipeline automation', 'Ad campaign snapshots', 'Priority support'],
+    highlighted: true
+  },
+  {
+    name: 'Pro',
+    price: '$599',
+    description: 'Enterprise governance for multi-asset teams.',
+    features: ['Advanced RBAC', 'Custom data residency', 'Dedicated success manager', 'Premium integrations']
+  }
+];
+
+const testimonials = [
+  {
+    quote: 'ClubCraft has replaced three tools and cut our reporting time in half.',
+    name: 'Jordan Wells',
+    role: 'Managing Partner, Summit Clubs'
+  },
+  {
+    quote: 'Our investor proposals now include live market data and marketing signals in minutes.',
+    name: 'Priya Shah',
+    role: 'Founder, VentureHouse'
+  },
+  {
+    quote: 'The glass dashboard makes it effortless to understand cash positions across properties.',
+    name: 'Miles Carter',
+    role: 'Treasurer, Skylight Collective'
+  }
+];
+
+export default function Page() {
+  return (
+    <main className="relative overflow-hidden">
+      <div className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(81,107,255,0.3),_transparent_55%)]" />
+      <Navbar />
+      <section className="mx-auto flex w-full max-w-6xl flex-col items-center gap-16 px-6 pb-24 pt-20 text-center">
+        <div className="glass-panel max-w-3xl border border-white/10 px-10 py-12">
+          <span className="rounded-full border border-white/20 bg-white/10 px-4 py-1 text-xs uppercase tracking-[0.3em] text-white/70">
+            Operate smarter clubs
+          </span>
+          <h1 className="mt-6 text-5xl font-bold leading-tight text-gradient">
+            Orchestrate every investment club in one glass dashboard
+          </h1>
+          <p className="mt-6 text-lg text-white/75">
+            ClubCraft combines governance, finance intelligence, and acquisition marketing into a single SaaS
+            platform so your team can deploy capital with clarity.
+          </p>
+          <div id="cta" className="mt-10 flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
+            <Link
+              href="/dashboard"
+              className="inline-flex items-center rounded-full bg-white/90 px-8 py-3 text-sm font-semibold text-slate-900 shadow-glass transition hover:bg-white"
+            >
+              Start Free Trial
+            </Link>
+            <Link href="#pricing" className="text-sm text-white/70 hover:text-white">
+              View pricing
+            </Link>
+          </div>
+        </div>
+        <div id="features" className="grid w-full gap-8 md:grid-cols-3">
+          {features.map((feature) => (
+            <div key={feature.title} className="glass-panel border border-white/10 p-6 text-left">
+              <h3 className="text-xl font-semibold text-white">{feature.title}</h3>
+              <p className="mt-3 text-sm text-white/70">{feature.description}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section id="pricing" className="bg-slate-950/40 py-24">
+        <div className="mx-auto flex w-full max-w-6xl flex-col gap-12 px-6">
+          <div className="text-center">
+            <h2 className="text-3xl font-semibold text-white">Pricing</h2>
+            <p className="mt-2 text-white/70">Choose a subscription that scales with your collective.</p>
+          </div>
+          <div className="grid gap-8 md:grid-cols-3">
+            {pricing.map((tier) => (
+              <PricingCard
+                key={tier.name}
+                name={tier.name}
+                price={tier.price}
+                description={tier.description}
+                features={tier.features}
+                highlighted={tier.highlighted}
+                cta={
+                  <Link
+                    href="/dashboard"
+                    className="inline-flex items-center justify-center rounded-full border border-white/30 bg-white/10 px-6 py-3 text-sm font-semibold text-white transition hover:bg-white/20"
+                  >
+                    Choose {tier.name}
+                  </Link>
+                }
+              />
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section id="testimonials" className="py-24">
+        <div className="mx-auto flex w-full max-w-6xl flex-col gap-12 px-6">
+          <div className="text-center">
+            <h2 className="text-3xl font-semibold text-white">Loved by modern club operators</h2>
+            <p className="mt-2 text-white/70">Thousands of members trust ClubCraft to handle governance, reporting, and growth.</p>
+          </div>
+          <div className="grid gap-8 md:grid-cols-3">
+            {testimonials.map((testimonial) => (
+              <TestimonialCard key={testimonial.name} {...testimonial} />
+            ))}
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/clubcraft-saas/frontend/components/Button.tsx
+++ b/clubcraft-saas/frontend/components/Button.tsx
@@ -1,0 +1,21 @@
+import { ComponentProps } from 'react';
+import { cn } from '../lib/cn';
+
+export type ButtonProps = ComponentProps<'button'> & {
+  variant?: 'primary' | 'secondary';
+};
+
+export function Button({ className, variant = 'primary', ...props }: ButtonProps) {
+  return (
+    <button
+      className={cn(
+        'inline-flex items-center justify-center rounded-full px-6 py-3 text-sm font-semibold transition-all duration-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2',
+        variant === 'primary'
+          ? 'bg-white/90 text-slate-900 shadow-glass hover:bg-white'
+          : 'border border-white/30 bg-white/10 text-white hover:bg-white/20',
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/clubcraft-saas/frontend/components/GlassCard.tsx
+++ b/clubcraft-saas/frontend/components/GlassCard.tsx
@@ -1,0 +1,23 @@
+import { ReactNode } from 'react';
+import { cn } from '../lib/cn';
+
+interface GlassCardProps {
+  title?: string;
+  description?: string;
+  children?: ReactNode;
+  className?: string;
+}
+
+export function GlassCard({ title, description, children, className }: GlassCardProps) {
+  return (
+    <div className={cn('glass-panel border border-white/10 p-6 backdrop-blur-lg', className)}>
+      {(title || description) && (
+        <div className="mb-4 space-y-1">
+          {title ? <h3 className="text-lg font-semibold text-white/90">{title}</h3> : null}
+          {description ? <p className="text-sm text-white/60">{description}</p> : null}
+        </div>
+      )}
+      {children}
+    </div>
+  );
+}

--- a/clubcraft-saas/frontend/components/Navbar.tsx
+++ b/clubcraft-saas/frontend/components/Navbar.tsx
@@ -1,0 +1,40 @@
+import Link from 'next/link';
+import { cn } from '../lib/cn';
+
+const links = [
+  { href: '#features', label: 'Features' },
+  { href: '#pricing', label: 'Pricing' },
+  { href: '#testimonials', label: 'Testimonials' }
+];
+
+export function Navbar() {
+  return (
+    <header className="sticky top-0 z-50 w-full border-b border-white/10 bg-slate-950/60 backdrop-blur-xl">
+      <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-4">
+        <Link href="/" className="text-xl font-semibold text-gradient">
+          ClubCraft
+        </Link>
+        <nav className="hidden items-center gap-8 text-sm text-white/70 sm:flex">
+          {links.map((link) => (
+            <a key={link.href} href={link.href} className="hover:text-white">
+              {link.label}
+            </a>
+          ))}
+        </nav>
+        <div className="flex items-center gap-3">
+          <Link href="/dashboard" className="text-sm text-white/70 hover:text-white">
+            Dashboard
+          </Link>
+          <Link
+            href="#cta"
+            className={cn(
+              'inline-flex items-center rounded-full bg-white/90 px-6 py-3 text-sm font-semibold text-slate-900 shadow-glass transition hover:bg-white'
+            )}
+          >
+            Start Free Trial
+          </Link>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/clubcraft-saas/frontend/components/PricingCard.tsx
+++ b/clubcraft-saas/frontend/components/PricingCard.tsx
@@ -1,0 +1,40 @@
+import { ReactNode } from 'react';
+import { cn } from '../lib/cn';
+
+interface PricingCardProps {
+  name: string;
+  price: string;
+  description: string;
+  features: string[];
+  cta?: ReactNode;
+  highlighted?: boolean;
+}
+
+export function PricingCard({ name, price, description, features, cta, highlighted }: PricingCardProps) {
+  return (
+    <div
+      className={cn(
+        'glass-panel flex flex-col gap-6 border border-white/15 p-8 transition-transform hover:-translate-y-1',
+        highlighted && 'border-white/40 bg-white/15 shadow-2xl'
+      )}
+    >
+      <div className="space-y-2">
+        <h3 className="text-2xl font-semibold text-white">{name}</h3>
+        <p className="text-sm text-white/70">{description}</p>
+      </div>
+      <div>
+        <span className="text-4xl font-bold text-white">{price}</span>
+        <span className="ml-1 text-sm text-white/60">/month</span>
+      </div>
+      <ul className="space-y-2 text-sm text-white/75">
+        {features.map((feature) => (
+          <li key={feature} className="flex items-start gap-2">
+            <span className="mt-1 h-1.5 w-1.5 rounded-full bg-primary-500" />
+            <span>{feature}</span>
+          </li>
+        ))}
+      </ul>
+      {cta}
+    </div>
+  );
+}

--- a/clubcraft-saas/frontend/components/TestimonialCard.tsx
+++ b/clubcraft-saas/frontend/components/TestimonialCard.tsx
@@ -1,0 +1,17 @@
+interface TestimonialCardProps {
+  quote: string;
+  name: string;
+  role: string;
+}
+
+export function TestimonialCard({ quote, name, role }: TestimonialCardProps) {
+  return (
+    <div className="glass-panel h-full border border-white/10 p-6">
+      <p className="text-lg text-white/90">“{quote}”</p>
+      <div className="mt-6">
+        <p className="text-sm font-semibold text-white">{name}</p>
+        <p className="text-xs text-white/60">{role}</p>
+      </div>
+    </div>
+  );
+}

--- a/clubcraft-saas/frontend/lib/cn.ts
+++ b/clubcraft-saas/frontend/lib/cn.ts
@@ -1,0 +1,6 @@
+import { clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: Array<string | undefined | null | false>) {
+  return twMerge(clsx(inputs));
+}

--- a/clubcraft-saas/frontend/next-env.d.ts
+++ b/clubcraft-saas/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/clubcraft-saas/frontend/next.config.js
+++ b/clubcraft-saas/frontend/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    serverActions: true
+  }
+};
+
+module.exports = nextConfig;

--- a/clubcraft-saas/frontend/package.json
+++ b/clubcraft-saas/frontend/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "frontend",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.0",
+    "framer-motion": "^10.18.0",
+    "lucide-react": "^0.378.0",
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "tailwind-merge": "^2.2.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.25",
+    "@types/react": "18.2.55",
+    "@types/react-dom": "18.2.18",
+    "autoprefixer": "^10.4.17",
+    "eslint": "^8.56.0",
+    "eslint-config-next": "14.1.0",
+    "postcss": "^8.4.33",
+    "tailwindcss": "^3.4.1",
+    "typescript": "5.3.3"
+  }
+}

--- a/clubcraft-saas/frontend/postcss.config.js
+++ b/clubcraft-saas/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/clubcraft-saas/frontend/tailwind.config.ts
+++ b/clubcraft-saas/frontend/tailwind.config.ts
@@ -1,0 +1,29 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          50: '#f1f5ff',
+          100: '#e0e8ff',
+          500: '#516bff',
+          600: '#3b4ed1'
+        }
+      },
+      backdropBlur: {
+        xs: '2px'
+      },
+      borderColor: {
+        glass: 'rgba(255,255,255,0.3)'
+      },
+      boxShadow: {
+        glass: '0 20px 45px -20px rgba(80,102,255,0.45)'
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/clubcraft-saas/frontend/tsconfig.json
+++ b/clubcraft-saas/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/clubcraft-saas/infra/main.tf
+++ b/clubcraft-saas/infra/main.tf
@@ -1,0 +1,60 @@
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.23"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+module "network" {
+  source = "terraform-aws-modules/vpc/aws"
+  name   = "clubcraft"
+  cidr   = "10.0.0.0/16"
+
+  azs             = slice(data.aws_availability_zones.available.names, 0, 3)
+  public_subnets  = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  private_subnets = ["10.0.11.0/24", "10.0.12.0/24", "10.0.13.0/24"]
+
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
+  enable_dns_hostnames = true
+}
+
+module "eks" {
+  source          = "./modules/eks"
+  cluster_name    = "clubcraft-eks"
+  vpc_id          = module.network.vpc_id
+  private_subnets = module.network.private_subnets
+}
+
+module "rds" {
+  source              = "./modules/rds"
+  vpc_security_groups = [module.network.default_security_group_id]
+  subnets             = module.network.private_subnets
+  db_name             = var.database_name
+  db_username         = var.database_username
+  db_password         = var.database_password
+}
+
+module "storage" {
+  source      = "./modules/s3"
+  bucket_name = var.asset_bucket_name
+}
+
+module "cdn" {
+  source        = "./modules/cloudfront"
+  bucket_domain = module.storage.bucket_domain
+  bucket_id     = module.storage.bucket_id
+}
+
+data "aws_availability_zones" "available" {}

--- a/clubcraft-saas/infra/modules/cloudfront/main.tf
+++ b/clubcraft-saas/infra/modules/cloudfront/main.tf
@@ -1,0 +1,54 @@
+variable "bucket_domain" {
+  type = string
+}
+
+variable "bucket_id" {
+  type = string
+}
+
+resource "aws_cloudfront_origin_access_identity" "this" {
+  comment = "ClubCraft OAI"
+}
+
+resource "aws_cloudfront_distribution" "this" {
+  enabled             = true
+  default_root_object = "index.html"
+
+  origin {
+    domain_name = var.bucket_domain
+    origin_id   = var.bucket_id
+
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.this.cloudfront_access_identity_path
+    }
+  }
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = var.bucket_id
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}
+
+output "domain_name" {
+  value = aws_cloudfront_distribution.this.domain_name
+}

--- a/clubcraft-saas/infra/modules/eks/main.tf
+++ b/clubcraft-saas/infra/modules/eks/main.tf
@@ -1,0 +1,36 @@
+variable "cluster_name" {
+  type = string
+}
+
+variable "vpc_id" {
+  type = string
+}
+
+variable "private_subnets" {
+  type = list(string)
+}
+
+module "eks" {
+  source          = "terraform-aws-modules/eks/aws"
+  cluster_name    = var.cluster_name
+  cluster_version = "1.29"
+  vpc_id          = var.vpc_id
+  subnet_ids      = var.private_subnets
+
+  eks_managed_node_groups = {
+    default = {
+      desired_capacity = 2
+      max_capacity     = 4
+      min_capacity     = 2
+      instance_types   = ["t3.medium"]
+    }
+  }
+}
+
+output "cluster_endpoint" {
+  value = module.eks.cluster_endpoint
+}
+
+output "cluster_security_group_id" {
+  value = module.eks.cluster_security_group_id
+}

--- a/clubcraft-saas/infra/modules/rds/main.tf
+++ b/clubcraft-saas/infra/modules/rds/main.tf
@@ -1,0 +1,46 @@
+variable "vpc_security_groups" {
+  type = list(string)
+}
+
+variable "subnets" {
+  type = list(string)
+}
+
+variable "db_name" {
+  type = string
+}
+
+variable "db_username" {
+  type = string
+}
+
+variable "db_password" {
+  type      = string
+  sensitive = true
+}
+
+resource "aws_db_subnet_group" "this" {
+  name       = "clubcraft-rds-subnet"
+  subnet_ids = var.subnets
+}
+
+resource "aws_db_instance" "this" {
+  identifier              = "clubcraft-db"
+  engine                  = "postgres"
+  engine_version          = "15.3"
+  instance_class          = "db.t3.medium"
+  allocated_storage       = 50
+  db_name                 = var.db_name
+  username                = var.db_username
+  password                = var.db_password
+  db_subnet_group_name    = aws_db_subnet_group.this.name
+  vpc_security_group_ids  = var.vpc_security_groups
+  skip_final_snapshot     = true
+  backup_retention_period = 7
+  multi_az                = false
+  publicly_accessible     = false
+}
+
+output "endpoint" {
+  value = aws_db_instance.this.endpoint
+}

--- a/clubcraft-saas/infra/modules/s3/main.tf
+++ b/clubcraft-saas/infra/modules/s3/main.tf
@@ -1,0 +1,40 @@
+variable "bucket_name" {
+  type = string
+}
+
+resource "aws_s3_bucket" "this" {
+  bucket = var.bucket_name
+}
+
+resource "aws_s3_bucket_versioning" "this" {
+  bucket = aws_s3_bucket.this.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_policy" "this" {
+  bucket = aws_s3_bucket.this.id
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Sid       = "AllowCloudFrontServicePrincipal",
+        Effect    = "Allow",
+        Principal = {
+          Service = "cloudfront.amazonaws.com"
+        },
+        Action = "s3:GetObject",
+        Resource = "${aws_s3_bucket.this.arn}/*"
+      }
+    ]
+  })
+}
+
+output "bucket_id" {
+  value = aws_s3_bucket.this.id
+}
+
+output "bucket_domain" {
+  value = aws_s3_bucket.this.bucket_regional_domain_name
+}

--- a/clubcraft-saas/infra/outputs.tf
+++ b/clubcraft-saas/infra/outputs.tf
@@ -1,0 +1,15 @@
+output "eks_cluster_endpoint" {
+  value = module.eks.cluster_endpoint
+}
+
+output "rds_endpoint" {
+  value = module.rds.endpoint
+}
+
+output "asset_bucket_id" {
+  value = module.storage.bucket_id
+}
+
+output "cloudfront_domain_name" {
+  value = module.cdn.domain_name
+}

--- a/clubcraft-saas/infra/variables.tf
+++ b/clubcraft-saas/infra/variables.tf
@@ -1,0 +1,28 @@
+variable "aws_region" {
+  type        = string
+  description = "AWS region for deployment"
+  default     = "us-east-1"
+}
+
+variable "database_name" {
+  type        = string
+  description = "Database name for Postgres"
+  default     = "clubcraft"
+}
+
+variable "database_username" {
+  type        = string
+  description = "Database admin username"
+  default     = "clubcraft"
+}
+
+variable "database_password" {
+  type        = string
+  description = "Database admin password"
+  sensitive   = true
+}
+
+variable "asset_bucket_name" {
+  type        = string
+  description = "S3 bucket for static assets"
+}

--- a/clubcraft-saas/package.json
+++ b/clubcraft-saas/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "clubcraft-saas",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "build": "pnpm -r build",
+    "dev": "pnpm --filter frontend dev",
+    "lint": "pnpm -r lint",
+    "test": "pnpm -r test"
+  }
+}

--- a/clubcraft-saas/pnpm-workspace.yaml
+++ b/clubcraft-saas/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+packages:
+  - 'frontend'
+  - 'backend'
+  - 'sdk/js'

--- a/clubcraft-saas/sdk/js/package.json
+++ b/clubcraft-saas/sdk/js/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@clubcraft/sdk",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsup src/index.ts --format esm,cjs --dts",
+    "lint": "eslint 'src/**/*.ts'",
+    "test": "echo 'No tests yet'"
+  },
+  "dependencies": {
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "eslint": "^8.56.0",
+    "typescript": "^5.3.3",
+    "tsup": "^8.0.1"
+  }
+}

--- a/clubcraft-saas/sdk/js/src/index.ts
+++ b/clubcraft-saas/sdk/js/src/index.ts
@@ -1,0 +1,63 @@
+import { z } from 'zod';
+
+const clubSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  description: z.string().nullable().optional()
+});
+
+type Club = z.infer<typeof clubSchema>;
+
+export interface ClubcraftClientOptions {
+  baseUrl: string;
+  token?: string;
+  fetchImpl?: typeof fetch;
+}
+
+export class ClubcraftClient {
+  private readonly baseUrl: string;
+  private token?: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(options: ClubcraftClientOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/$/, '');
+    this.token = options.token;
+    this.fetchImpl = options.fetchImpl ?? fetch;
+  }
+
+  setToken(token: string) {
+    this.token = token;
+  }
+
+  private async request<T>(path: string, init?: RequestInit) {
+    const response = await this.fetchImpl(`${this.baseUrl}${path}`, {
+      ...init,
+      headers: {
+        'Content-Type': 'application/json',
+        ...(this.token ? { Authorization: `Bearer ${this.token}` } : {}),
+        ...init?.headers
+      }
+    });
+
+    if (!response.ok) {
+      throw new Error(`Request failed with status ${response.status}`);
+    }
+
+    return (await response.json()) as T;
+  }
+
+  clubs = {
+    list: async (): Promise<Club[]> => {
+      const result = await this.request<{ data: unknown }>('/clubs');
+      const parsed = z.object({ data: z.array(clubSchema) }).parse(result);
+      return parsed.data;
+    },
+    create: async (input: { name: string; description?: string }): Promise<Club> => {
+      const result = await this.request<unknown>('/clubs', {
+        method: 'POST',
+        body: JSON.stringify(input)
+      });
+      return clubSchema.parse(result);
+    }
+  };
+}

--- a/clubcraft-saas/sdk/js/tsconfig.json
+++ b/clubcraft-saas/sdk/js/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/clubcraft-saas/sdk/python/clubcraft/__init__.py
+++ b/clubcraft-saas/sdk/python/clubcraft/__init__.py
@@ -1,0 +1,3 @@
+from .client import ClubcraftClient
+
+__all__ = ["ClubcraftClient"]

--- a/clubcraft-saas/sdk/python/clubcraft/client.py
+++ b/clubcraft-saas/sdk/python/clubcraft/client.py
@@ -1,0 +1,48 @@
+from typing import Any, Dict, List, Optional
+
+import httpx
+from pydantic import BaseModel, ValidationError
+
+
+class Club(BaseModel):
+    id: str
+    name: str
+    description: Optional[str] = None
+
+
+class ClubcraftClient:
+    def __init__(self, base_url: str, token: Optional[str] = None, *, timeout: Optional[float] = 10.0) -> None:
+        self.base_url = base_url.rstrip('/')
+        self.token = token
+        self.timeout = timeout
+        self._client = httpx.AsyncClient(base_url=self.base_url, timeout=self.timeout)
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+    def set_token(self, token: str) -> None:
+        self.token = token
+
+    async def _request(self, method: str, path: str, json: Optional[Dict[str, Any]] = None) -> Any:
+        headers = {'Content-Type': 'application/json'}
+        if self.token:
+            headers['Authorization'] = f'Bearer {self.token}'
+
+        response = await self._client.request(method, path, json=json, headers=headers)
+        response.raise_for_status()
+        return response.json()
+
+    async def list_clubs(self) -> List[Club]:
+        data = await self._request('GET', '/clubs')
+        try:
+            clubs = [Club(**item) for item in data.get('data', [])]
+        except ValidationError as exc:
+            raise ValueError('Invalid club payload') from exc
+        return clubs
+
+    async def create_club(self, name: str, description: Optional[str] = None) -> Club:
+        payload = await self._request('POST', '/clubs', json={'name': name, 'description': description})
+        try:
+            return Club(**payload)
+        except ValidationError as exc:
+            raise ValueError('Invalid club response') from exc

--- a/clubcraft-saas/sdk/python/pyproject.toml
+++ b/clubcraft-saas/sdk/python/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "clubcraft"
+version = "0.1.0"
+description = "Python SDK for ClubCraft API"
+requires-python = ">=3.10"
+authors = [{ name = "ClubCraft" }]
+dependencies = [
+  "httpx>=0.25.0",
+  "pydantic>=2.5.0"
+]
+
+[project.optional-dependencies]
+dev = ["pytest"]
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary
- create a pnpm workspace for the ClubCraft SaaS stack with Next.js glassmorphism marketing and dashboard pages
- deliver a Fastify + Prisma backend with JWT auth, clubs CRUD, Stripe billing hooks, caching, and third-party service stubs
- add Terraform infrastructure modules, multi-language SDK starters, local environment config, and CI/CD pipeline

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d4452d66f8832da173bab8587b6e71